### PR TITLE
Optimize dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
       "guzzlehttp/guzzle": "*",
       "ext-json": "*",
       "google/protobuf": "*",
-      "google/gax": "*",
       "ext-openssl": "*"
     },
     "autoload": {


### PR DESCRIPTION
CHANGE：删除未使用的 `google/gax`  包，某些情况下虽然没有依赖互斥，但是会导致包降级
![image](https://github.com/volcengine/volc-sdk-php/assets/15704489/bff8f44f-8842-41a0-be01-0aa30e187440)

BC：无

SUGGEST：建议对 `google/protobuf` 进行版本框定，不要使用 ‘*’，因为大版本的变更可能会有BC.